### PR TITLE
feat: 初版ドラフトを折りたたみ表示に変更し、質問を優先表示

### DIFF
--- a/tests/test_hearing_ui.py
+++ b/tests/test_hearing_ui.py
@@ -1,0 +1,143 @@
+"""Tests for hearing UI display logic based on draft version."""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Add project root to path
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from app.state import Idea
+
+
+class TestHearingUIDisplay:
+    """Test hearing_ui function displays correctly based on draft version."""
+
+    @patch("app.main.st")
+    def test_first_version_shows_questions_first_with_collapsed_draft(self, mock_st):
+        """初版では質問が先に表示され、ドラフトは折りたたまれているか確認."""
+        from app.main import hearing_ui
+
+        # Arrange: 初版のアイデア
+        idea = Idea(
+            id="test-1",
+            title="Test Idea",
+            category="防災",
+            description="Test description",
+            draft_spec_markdown="# 初版ドラフト内容",
+            draft_version=1,
+            messages=[
+                {"role": "assistant", "content": "質問1: これは緊急時に使用されますか？"},
+                {"role": "assistant", "content": "質問2: 既存の技術を改良したものですか？"},
+            ],
+        )
+
+        # Mock session state
+        mock_st.session_state.ideas = [idea]
+
+        # Act
+        with patch("app.main._load_instruction_markdown", return_value="instruction"):
+            with patch("app.main.save_ideas"):
+                hearing_ui(idea)
+
+        # Assert
+        # 1. AIヒアリングのsubheaderが最初に呼ばれる
+        subheader_calls = [
+            call for call in mock_st.subheader.call_args_list if call[0][0] == "AI ヒアリング"
+        ]
+        assert len(subheader_calls) > 0, "AI ヒアリングのサブヘッダーが表示されていない"
+
+        # 2. expanderでドラフトが折りたたまれている
+        expander_calls = mock_st.expander.call_args_list
+        assert any(
+            "生成された明細書ドラフト（第1版）" in str(call) for call in expander_calls
+        ), "初版ドラフトがexpanderで表示されていない"
+
+        # 3. エクスポートボタンがない
+        assert mock_st.download_button.call_count == 0, "初版でエクスポートボタンが表示されている"
+
+    @patch("app.main.st")
+    def test_second_version_shows_draft_first_with_all_features(self, mock_st):
+        """2版以降ではドラフトが先に表示され、全機能が有効か確認."""
+        from app.main import hearing_ui
+
+        # Arrange: 2版のアイデア
+        idea = Idea(
+            id="test-2",
+            title="Test Idea",
+            category="防災",
+            description="Test description",
+            draft_spec_markdown="# 第2版ドラフト内容",
+            draft_version=2,
+            messages=[
+                {"role": "assistant", "content": "質問1: これは緊急時に使用されますか？"},
+                {"role": "user", "content": "はい"},
+                {"role": "assistant", "content": "質問2: 既存の技術を改良したものですか？"},
+            ],
+        )
+
+        # Mock session state
+        mock_st.session_state.ideas = [idea]
+
+        # Act
+        with patch("app.main._load_instruction_markdown", return_value="instruction"):
+            with patch("app.main.save_ideas"):
+                with patch("app.main.export_docx", return_value=("test.docx", b"data")):
+                    with patch("app.main.export_pdf", return_value=("test.pdf", b"data")):
+                        hearing_ui(idea)
+
+        # Assert
+        # 1. ドラフトのsubheaderが最初に表示される
+        subheader_calls = mock_st.subheader.call_args_list
+        assert any(
+            "ドラフト（第2版）" in str(call) for call in subheader_calls
+        ), "2版のドラフトサブヘッダーが表示されていない"
+
+        # 2. ドラフト編集用のexpanderがある
+        expander_calls = mock_st.expander.call_args_list
+        assert any(
+            "ドラフトを編集" in str(call) for call in expander_calls
+        ), "ドラフト編集用expanderが表示されていない"
+
+        # 3. エクスポートボタンが表示される（Word & PDF）
+        assert mock_st.download_button.call_count >= 2, "エクスポートボタンが表示されていない"
+
+    @patch("app.main.st")
+    def test_questions_display_logic_works_in_both_versions(self, mock_st):
+        """両方のバージョンで質問表示ロジックが正常動作するか確認."""
+        from app.main import hearing_ui
+
+        # Arrange: 未回答質問があるアイデア
+        idea = Idea(
+            id="test-3",
+            title="Test Idea",
+            category="防災",
+            description="Test description",
+            draft_spec_markdown="# ドラフト内容",
+            draft_version=1,
+            messages=[
+                {"role": "assistant", "content": "これは防災用ですか？"},
+                {"role": "assistant", "content": "既存技術の改良ですか？"},
+            ],
+        )
+
+        # Mock session state
+        mock_st.session_state.ideas = [idea]
+        mock_st.form.return_value.__enter__ = MagicMock()
+        mock_st.form.return_value.__exit__ = MagicMock()
+
+        # Act
+        with patch("app.main._load_instruction_markdown", return_value="instruction"):
+            with patch("app.main.save_ideas"):
+                hearing_ui(idea)
+
+        # Assert: 質問フォームが表示される
+        form_calls = mock_st.form.call_args_list
+        assert len(form_calls) > 0, "質問フォームが表示されていない"
+        assert any("qa-form" in str(call) for call in form_calls), "質問フォームのIDが正しくない"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## 概要
初版のドラフトでユーザーを驚かせないよう、表示順序と方法を改善しました。

## 変更内容
### 初版（draft_version == 1）の表示
- 💬 **質問を先に表示**：AIヒアリングセクションを最上部に配置
- 📄 **ドラフトは折りたたみ表示**：`st.expander`で控えめに表示
- 🚫 **編集・エクスポート機能を非表示**：初版では必要ないため

### 2版以降の表示
- ✅ 現在の表示を維持（ドラフト優先、全機能表示）

### コード改善
- `_render_hearing_section`関数として質問表示ロジックを共通化
- TDDに従い、テストを先に作成してから実装

## テスト
- 初版と2版以降の表示確認テストを追加
- 質問表示ロジックの動作確認テストを追加

## 動作確認方法
1. 新規アイデアを作成
2. 初版では質問が先に表示され、ドラフトが折りたたまれていることを確認
3. 質問に回答して2版を生成
4. 2版ではドラフトが先に表示され、編集・エクスポート機能が有効なことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)