### PR TITLE
fix: Streamlit Cloudの再起動を抑止（PDF抽出の警告抑制＆抽出結果キャッシュ）

### DIFF
--- a/app/state.py
+++ b/app/state.py
@@ -16,6 +16,8 @@ class Attachment:
     upload_time: datetime = field(default_factory=datetime.now)
     gemini_file_id: Optional[str] = None
     gemini_mime_type: Optional[str] = None
+    # Store extracted text to avoid re-parsing (especially for PDFs)
+    extracted_text: Optional[str] = None
 
 
 @dataclass


### PR DESCRIPTION
### 概要
Streamlit Community Cloud で「Advanced encoding /90ms-RKSJ-H not implemented yet」等の大量ログが発生し、ワーカーが再起動（リブート）してしまう事象を解消しました。原因は pypdf による日本語PDFのテキスト抽出時警告の氾濫と、添付再処理時の再抽出多発でした。抽出結果のキャッシュ保存と pypdf ログ抑制で安定化しています。

### 背景
- LLM 呼び出し自体は正常完了（FinishReason=STOP）だが、直後に Cloud が「Disconnecting → Provisioning」と再起動。
- ログに `Advanced encoding /90ms-RKSJ-H not implemented yet` が多数出力。これは pypdf の既知の警告で、日本語 PDF（CID/高度エンコーディング）で発生。
- UI 側で添付の整形・再生成のたびにローカルPDF抽出が走り、警告が雪だるま式に増加していた。

### 変更点
- fix(state): 添付に抽出テキストを永続化
  - `app/state.py`: `Attachment` に `extracted_text: Optional[str]` を追加し、一度抽出した内容を保存。
- fix(main): 再抽出を回避し、pypdf 警告を抑制
  - `app/main.py` 新規作成/追加時に `extracted_text` を保存（行: 188-199, 641-650）。
  - `_prepare_attachment_dicts` で `extracted_text` があればそれを利用し、不要な再抽出を防止（行: 381-401）。
  - `logging.getLogger("pypdf").setLevel(logging.ERROR)` で pypdf ロガーの冗長出力を抑止（行: 38-39）。
- 挙動の互換性は維持しつつ、Gemini ファイルIDがある場合は従来どおり LLM 側にファイルを渡す設計を維持。

### 確認方法
1. 日本語PDF（RKSJ/90ms-RKSJ-H 系）を添付してアイデア作成。
2. 「回答をまとめて送信」で再生成を複数回実施。
3. 以下を確認:
   - ターミナル/Cloud ログに `Advanced encoding /90ms-RKSJ-H ...` が出力されない（または極小）。
   - アプリがリブートせずに対話・再生成が継続する。

### 影響範囲
- 添付の内部表現（`Attachment`）に `extracted_text` が増えるため、既存 `data/ideas.json` から読み出す際に問題はありません（フィールド追加は後方互換）。
- PDF 以外（画像/テキスト/Office）の処理にも副作用はありません。

### リスク・互換性
- 低リスク：抽出結果のキャッシュ導入とログ抑制のみで、コアの LLM 連携仕様は不変。
- 既存データに対してはフィールド追加のみで互換。

### 関連・メモ
- 将来の選択肢として、Cloud 環境ではローカルPDF抽出を完全無効化し常に Gemini 抽出にフォールバックするフラグ（例: `DISABLE_LOCAL_PDF_EXTRACT=1`）の導入が可能です。
- 「次の質問」生成を `gemini-2.5-flash` に固定する運用も、安定性/コストに寄与します。

### テスト結果（ローカル）
- `uv run pytest -q`: 145 passed
- `uv run ruff check app/` / `uv run ruff format app/`: OK
- `uv run pre-commit run --all-files`: 全フック通過
