### PR TITLE
feat(ui): サイドバーに『トップへ戻る』ボタンを追加

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -94,6 +94,15 @@ def sidebar_ui():
     ideas: List[Idea] = st.session_state.ideas
     state: AppState = st.session_state.app_state
 
+    # Always-available Home navigation (without logging out)
+    if st.sidebar.button("🏠 トップへ戻る", use_container_width=True):
+        state.selected_idea_id = None
+        state.show_new_idea_form = False
+        # Clear transient flags such as hearing start
+        if "start_hearing" in st.session_state:
+            st.session_state.pop("start_hearing", None)
+        st.rerun()
+
     model_options = ["gemini-2.5-pro", "gemini-2.5-flash"]
     current_index = (
         model_options.index(state.gemini_model) if state.gemini_model in model_options else 0


### PR DESCRIPTION
### 概要
ログアウトせずに「トップページ（アイデア未選択の初期画面）」へいつでも戻れるよう、サイドバーに「🏠 トップへ戻る」ボタンを追加しました。

### 背景
- 対話や編集中にトップへ戻る導線が乏しく、戻るために不要なログアウト操作が行われるケースがあった。
- UX 改善として、常時表示のナビゲーションをサイドバー上部に配置。

### 変更点
- feat(ui): サイドバーにトップ戻りボタンを追加
  - `app/main.py` `sidebar_ui()` に「🏠 トップへ戻る」を追加。
  - クリック時に以下をリセットし `st.rerun()`：
    - `AppState.selected_idea_id = None`
    - `AppState.show_new_idea_form = False`
    - `st.session_state["start_hearing"]`（存在時のみ）を削除

### 確認方法
1. いずれかのアイデアを選択して詳細画面へ遷移。
2. サイドバー上部の「🏠 トップへ戻る」をクリック。
3. トップページ（「左のサイドバーからアイデアを選択するか、新規作成してください。」の表示）に戻ることを確認。
4. 認証状態（ログインユーザー表示）が保持されることを確認（ログアウトは不要）。

### 影響範囲
- UI のみ。永続化データや LLM 呼び出しロジックへの影響なし。

### リスク・互換性
- 低リスク：セッションフラグのリセットのみで、既存フローと互換。

### 関連・メモ
- 必要に応じて、メインエリアにも同様のボタンを配置可能（本PRではサイドバーのみ）。

### テスト結果（ローカル）
- `uv run pytest -q`: 145 passed
- `uv run ruff check app/` / `uv run ruff format app/`: OK
- `uv run pre-commit run --all-files`: 全フック通過
