### PR TITLE
chore(ui): サイドバーで『アイデア一覧』をGeminiモデル選択の下に配置

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -94,6 +94,15 @@ def sidebar_ui():
     ideas: List[Idea] = st.session_state.ideas
     state: AppState = st.session_state.app_state
 
+    # Always-available Home navigation (without logging out)
+    if st.sidebar.button("🏠 トップへ戻る", use_container_width=True):
+        state.selected_idea_id = None
+        state.show_new_idea_form = False
+        # Clear transient flags such as hearing start
+        if "start_hearing" in st.session_state:
+            st.session_state.pop("start_hearing", None)
+        st.rerun()
+
     model_options = ["gemini-2.5-pro", "gemini-2.5-flash"]
     current_index = (
         model_options.index(state.gemini_model) if state.gemini_model in model_options else 0

--- a/app/main.py
+++ b/app/main.py
@@ -90,7 +90,6 @@ def init_session_state() -> None:
 
 
 def sidebar_ui():
-    st.sidebar.title("アイデア一覧")
     ideas: List[Idea] = st.session_state.ideas
     state: AppState = st.session_state.app_state
 
@@ -111,6 +110,9 @@ def sidebar_ui():
     if selected_model != state.gemini_model:
         state.gemini_model = selected_model
         os.environ["GEMINI_MODEL"] = selected_model
+
+    # Move the idea list title below the model selector
+    st.sidebar.title("アイデア一覧")
 
     # New idea button
     if st.sidebar.button("＋ 新規アイデアを作成", use_container_width=True):


### PR DESCRIPTION
### 概要
サイドバーのレイアウトを調整し、「Geminiモデル」セレクトの下に「アイデア一覧」を表示するようにしました。あわせて、先行PRで追加した「🏠 トップへ戻る」は据え置きで最上部に配置しています。

### 背景
- モデル選択とアイデア一覧の並び順が直感的ではなかったため、モデル選択 → アイデア一覧の順に統一し、操作性を改善。

### 変更点
- feat(ui): サイドバーの表示順序を変更
  - `app/main.py` `sidebar_ui()` で「アイデア一覧」の見出しをモデルセレクトの直下へ移動。
  - 「🏠 トップへ戻る」は現状の最上部に維持。

### 確認方法
1. アプリを起動し、サイドバーの「Geminiモデル」セレクトの下に「アイデア一覧」の見出しとリストが表示されることを確認。
2. モデルを切替えてもレイアウトが崩れないことを確認。

### 影響範囲
- UI のみ。永続化データや LLM 呼び出しロジックへの影響なし。

### リスク・互換性
- 低リスク：セッションフラグのリセットのみで、既存フローと互換。

### 関連・メモ
- 必要に応じて、メインエリアにも同様のボタンを配置可能（本PRではサイドバーのみ）。

### テスト結果（ローカル）
- `uv run pytest -q`: 145 passed
- `uv run ruff check app/` / `uv run ruff format app/`: OK
- `uv run pre-commit run --all-files`: 全フック通過
