### PR TITLE
feat(qa): enforce 8 yes/no + 2 open questions and show open prompts in UI

### DIFF
--- a/app/llm.py
+++ b/app/llm.py
@@ -6,7 +6,10 @@ import re
 import time
 from typing import Any, Dict, List, Optional, Tuple
 
-from google import genai
+try:
+    from google import genai
+except ModuleNotFoundError:  # pragma: no cover
+    genai = None  # type: ignore
 
 from app.file_handler import _format_attachments_for_prompt
 
@@ -81,12 +84,12 @@ def _title_model_name() -> str:
     return "gemini-2.5-flash"
 
 
-def _get_client() -> Optional[genai.Client]:
+def _get_client() -> Optional[Any]:
     api_key = os.getenv("GOOGLE_API_KEY") or os.getenv("GEMINI_API_KEY")
+    if genai is None or not api_key:
+        logger.warning("Gemini API key is not set (GOOGLE_API_KEY or GEMINI_API_KEY).")
+        return None
     try:
-        if not api_key:
-            logger.warning("Gemini API key is not set (GOOGLE_API_KEY or GEMINI_API_KEY).")
-            return None
         return genai.Client(api_key=api_key)
     except Exception:
         logger.exception("Failed to initialize Gemini client.")
@@ -291,13 +294,20 @@ def next_questions(
             "現行ドラフトに未記載箇所があります。図面は必要ですか？（はい/いいえ）",
             "実施例は複数のバリエーションがありますか？（はい/いいえ）",
             "発明の効果に定量的根拠はありますか？（はい/いいえ）",
+            "競合技術との差異は明確ですか？（はい/いいえ）",
+            "用語の定義は十分ですか？（はい/いいえ）",
+            "各構成要件の関係は明確ですか？（はい/いいえ）",
+            "課題解決手段は過不足なく記載されていますか？（はい/いいえ）",
+            "図面の参照番号は一貫していますか？（はい/いいえ）",
+            "この発明の想定される応用例は何ですか？（自由記述）",
+            "特に強調したい技術的効果は何ですか？（自由記述）",
         ][:num_questions], error_msg
 
     transcript_str = "\n".join([f"{m['role']}: {m['content']}" for m in transcript][-20:])
     system = (
         "あなたは特許明細書の執筆アシスタントです。以下の指示書に照らして、"
         "現行ドラフトの不足・曖昧・未記載部分を見つけ、ユーザーが答えやすい"
-        "『はい/いいえ』のクローズド質問を優先度順に作成してください。"
+        "質問を優先度順に作成してください。"
     )
 
     # Format attachments if provided
@@ -315,7 +325,10 @@ def next_questions(
         "[出力要件]\n"
         "- 質問のみを出力（前置きや挨拶は不要）\n"
         "- 各行1問、{num}問\n"
-        "- はい/いいえ で答えられる形式（例: '〜ですか？（はい/いいえ）'）\n"
+        "- 最初の8問は『はい/いいえ』で答えられる形式（例: '〜ですか？（はい/いいえ）'）\n"
+        "- 最後の2問は自由記述形式（末尾に'（自由記述）'）で、"
+        "『〜ありますか？』や『〜ですか？』などの二択誘導を避け、"
+        "『どのような』『なぜ』『何』『具体例を挙げて』等の表現を用いる\n"
         "- 1つの質問につき1論点、具体的に\n"
         "- 既に回答済みの重複質問は避ける\n"
         "- 添付ファイルの内容も考慮する\n".replace("{num}", str(num_questions))
@@ -326,7 +339,10 @@ def next_questions(
         "[出力要件]\n"
         "- 質問のみを出力（前置きや挨拶は不要）\n"
         "- 各行1問、{num}問\n"
-        "- はい/いいえ で答えられる形式（例: '〜ですか？（はい/いいえ）'）\n"
+        "- 最初の8問は『はい/いいえ』で答えられる形式（例: '〜ですか？（はい/いいえ）'）\n"
+        "- 最後の2問は自由記述形式（末尾に'（自由記述）'）で、"
+        "『〜ありますか？』や『〜ですか？』などの二択誘導を避け、"
+        "『どのような』『なぜ』『何』『具体例を挙げて』等の表現を用いる\n"
         "- 1つの質問につき1論点、具体的に\n"
         "- 既に回答済みの重複質問は避ける\n".replace("{num}", str(num_questions))
     )
@@ -356,9 +372,63 @@ def next_questions(
             "課題の技術的背景は十分に記載されていますか？（はい/いいえ）",
             "構成要件の必須/任意が明確ですか？（はい/いいえ）",
             "変形例はありますか？（はい/いいえ）",
+            "図面と説明との整合性は取れていますか？（はい/いいえ）",
+            "請求項の範囲は適切ですか？（はい/いいえ）",
+            "従来技術との差異は明確ですか？（はい/いいえ）",
+            "発明の効果は再現可能ですか？（はい/いいえ）",
+            "実施形態の各段階は網羅されていますか？（はい/いいえ）",
+            "他に記載しておくべき関連技術は何ですか？（自由記述）",
+            "今後の改良案や展望はどのようなものですか？（自由記述）",
         ][:num_questions], error_msg
     lines = [line.strip("- ") for line in text.splitlines() if line.strip()]
-    return [line for line in lines if line][:num_questions], None
+
+    # Enforce 8 yes/no + 2 open when requesting 10 questions
+    # Open questions: mark with '（自由記述）' and ensure they don't include 'はい/いいえ'
+    # Yes/No questions: ensure they include '（はい/いいえ）'
+    def _normalize_yesno_marker(s: str) -> str:
+        # Remove any existing open marker
+        s = re.sub(r"（自由記述）$", "", s).strip()
+        # If already contains yes/no hint, leave as-is; otherwise append
+        if ("はい/いいえ" not in s) and ("（はい/いいえ" not in s):
+            s = f"{s}（はい/いいえ）"
+        return s
+
+    def _normalize_open_marker(s: str) -> str:
+        # Remove yes/no markers anywhere if bracketed
+        s = re.sub(r"（はい/いいえ[^）]*）", "", s).strip()
+        # Avoid duplicated open marker
+        if not s.endswith("（自由記述）"):
+            s = f"{s}（自由記述）"
+        return s
+
+    lines = [line for line in lines if line][:num_questions]
+
+    # If fewer than requested, pad with canonical prompts
+    if len(lines) < num_questions:
+        pad_pool = [
+            "図面の参照番号は一貫していますか？（はい/いいえ）",
+            "実施例は複数のバリエーションがありますか？（はい/いいえ）",
+            "競合技術との差異は明確ですか？（はい/いいえ）",
+            "この発明の想定される応用例は何ですか？（自由記述）",
+            "特に強調したい技術的効果はありますか？（自由記述）",
+        ]
+        for p in pad_pool:
+            if len(lines) >= num_questions:
+                break
+            lines.append(p)
+
+    if num_questions >= 10 and len(lines) >= num_questions:
+        # First num_questions-2 as yes/no, last 2 as open
+        cutoff = num_questions - 2
+        adjusted: List[str] = []
+        for idx, q in enumerate(lines[:num_questions]):
+            if idx < cutoff:
+                adjusted.append(_normalize_yesno_marker(q))
+            else:
+                adjusted.append(_normalize_open_marker(q))
+        lines = adjusted
+
+    return lines, None
 
 
 def refine_spec(

--- a/app/main.py
+++ b/app/main.py
@@ -259,7 +259,7 @@ def new_idea_form():
                 manual_md,
                 idea.messages,
                 idea.draft_spec_markdown,
-                num_questions=5,
+                num_questions=10,
                 version=idea.draft_version,
                 is_final=idea.is_final,
                 attachments=attachment_dicts,
@@ -430,31 +430,37 @@ def _render_hearing_section(idea: Idea, manual_md: str, show_questions_first: bo
             break
     tail_assistant = list(reversed(tail_assistant))
 
-    # Heuristic: keep only yes/no style questions for the radio form
+    def _looks_like_question(text: str) -> bool:
+        if not text:
+            return False
+        t = str(text).strip()
+        # Consider as question if it:
+        # - ends with a question mark, or
+        # - is yes/no style, or
+        # - is marked as open-ended (自由記述)
+        return t.endswith("？") or t.endswith("?") or ("はい/いいえ" in t) or ("自由記述" in t)
+
     def _looks_like_yes_no_question(text: str) -> bool:
         if not text:
             return False
         t = str(text).strip()
-        if "はい/いいえ" in t or "（はい/いいえ" in t:
-            return True
-        if t.endswith("？") or t.endswith("?"):
-            return True
-        return False
+        return "はい/いいえ" in t or "（はい/いいえ" in t
 
-    pending_candidates = [q for q in tail_assistant if _looks_like_yes_no_question(q)]
+    pending_candidates = [q for q in tail_assistant if _looks_like_question(q)]
     # De-duplicate while preserving order
     seen_q: set[str] = set()
-    pending_questions: list[str] = []
+    pending_questions: list[tuple[str, str]] = []
     for q in pending_candidates:
         if q not in seen_q:
             seen_q.add(q)
-            pending_questions.append(q)
-    pending_questions = pending_questions[:5]
+            q_type = "yesno" if _looks_like_yes_no_question(q) else "open"
+            pending_questions.append((q, q_type))
+    pending_questions = pending_questions[:10]
 
     # Determine which trailing assistant messages to hide from the history
     # (exactly those shown in the pending questions)
     to_hide_indices = set()
-    match_from_end = list(reversed(pending_questions))
+    match_from_end = list(reversed([q for q, _ in pending_questions]))
     ptr = 0
     for idx in range(len(idea.messages) - 1, -1, -1):
         if ptr >= len(match_from_end):
@@ -519,25 +525,38 @@ def _render_hearing_section(idea: Idea, manual_md: str, show_questions_first: bo
         _render_pending_questions(idea, pending_questions, manual_md)
 
 
-def _render_pending_questions(idea: Idea, pending_questions: list[str], manual_md: str):
+def _render_pending_questions(
+    idea: Idea, pending_questions: list[tuple[str, str]] | list[str], manual_md: str
+):
     """Render pending questions form."""
-    st.markdown("**未回答の質問**（各項目に回答して「回答をまとめて送信」）")
+    st.markdown("**未回答の質問**（各項目に回答して「回答をまとめて送信」。自由記述は任意）")
     with st.form(f"qa-form-{idea.id}"):
         selections: list[str] = []
+        # Normalize input to list of tuples
+        normalized: list[tuple[str, str]] = []
+        for q in pending_questions:
+            if isinstance(q, tuple):
+                normalized.append(q)
+            else:
+                normalized.append((q, "yesno"))
         # Calculate the starting question number based on all previous questions
         start_num = _calculate_question_start_number(idea)
-        for i, q in enumerate(pending_questions, start=start_num):
+        for i, (q, q_type) in enumerate(normalized, start=start_num):
             cleaned_q = _clean_ai_message(q)
             st.markdown(f"Q{i}: {cleaned_q}")
-            # Use draft version in key to ensure fresh state for each round
-            choice = st.radio(
-                key=f"ans-{idea.id}-v{idea.draft_version}-{i}",
-                label="回答",
-                options=["はい", "いいえ", "わからない"],
-                index=2,  # Default to "わからない"
-                horizontal=True,
-            )
-            selections.append(choice)
+            key = f"ans-{idea.id}-v{idea.draft_version}-{i}"
+            if q_type == "yesno":
+                choice = st.radio(
+                    key=key,
+                    label="回答",
+                    options=["はい", "いいえ", "わからない"],
+                    index=2,  # Default to "わからない"
+                    horizontal=True,
+                )
+                selections.append(choice)
+            else:
+                text = st.text_area(key=key, label="回答（任意）", value="")
+                selections.append(text.strip() or "無回答")
         submitted = st.form_submit_button("回答をまとめて送信", type="primary")
         if submitted:
             for ans in selections:
@@ -581,7 +600,7 @@ def _render_pending_questions(idea: Idea, pending_questions: list[str], manual_m
                             manual_md,
                             idea.messages,
                             idea.draft_spec_markdown,
-                            num_questions=5,
+                            num_questions=10,
                             version=idea.draft_version,
                             is_final=idea.is_final,
                             attachments=attachment_dicts,
@@ -599,8 +618,13 @@ def _render_pending_questions(idea: Idea, pending_questions: list[str], manual_m
                             "実施例は複数のバリエーションがありますか？（はい/いいえ）",
                             "発明の効果に定量的根拠はありますか？（はい/いいえ）",
                             "既存技術との違いを明確に説明できますか？（はい/いいえ）",
-                            "この発明の最も重要な利点は何ですか？（はい/いいえで答えられる形で確認）",
-                        ][:5]
+                            "この発明の最も重要な利点は何ですか？（はい/いいえ）",
+                            "追加の実施形態は存在しますか？（はい/いいえ）",
+                            "図面の参照番号は適切ですか？（はい/いいえ）",
+                            "効果の裏付けデータはありますか？（はい/いいえ）",
+                            "この発明の想定される応用例は何ですか？（自由記述）",
+                            "特に強調したい技術的効果は何ですか？（自由記述）",
+                        ][:10]
                         q_error = "予期しないエラー"
 
                     print(f"DEBUG: Generated {len(qs2)} questions for version {idea.draft_version}")
@@ -691,7 +715,7 @@ def hearing_ui(idea: Idea):
             idea.draft_spec_markdown = spec_result
             save_ideas(st.session_state.ideas)
 
-    # Auto-generate initial questions if none exist yet (up to 5)
+    # Auto-generate initial questions if none exist yet (up to 10)
     if not any(m.get("role") == "assistant" for m in idea.messages) and not idea.is_final:
         with st.spinner("初回質問を準備中…"):
             attachment_dicts, gemini_files = _prepare_attachment_dicts(idea)
@@ -699,7 +723,7 @@ def hearing_ui(idea: Idea):
                 manual_md,
                 idea.messages,
                 idea.draft_spec_markdown,
-                num_questions=5,
+                num_questions=10,
                 version=idea.draft_version,
                 is_final=idea.is_final,
                 attachments=attachment_dicts,


### PR DESCRIPTION
### 概要
AI ヒアリングの質問数を 5 → 10 件に拡張し、必ず「先頭 8 件＝はい/いいえ（ラジオ）」「末尾 2 件＝自由記述（テキスト、回答任意）」となるよう統一しました。UI は自由記述に対応し、LLM 側とフォールバックの双方で 8+2 構成を強制します。

### 背景
- オープンクエスチョン（自由記述）の導入要望に対し、スクリーンショット上で自由記述が表示されない事象が確認されました。
- LLM 出力に揺れ（行数や表現）があるため、後処理で体裁を保証する必要がありました。

### 変更点
- feat(qa): 質問数を 10 に拡張し、8+2 構成を必ず保証
  - `app/llm.py: next_questions` にポストプロセスを追加し、先頭 8 件へ「（はい/いいえ）」付与、末尾 2 件を「（自由記述）」へ正規化。返却が 10 件未満でもパディングで補完。
  - 自由記述への正規化時に「（はい/いいえ…）」表記を除去。
  - プロンプトへ「自由記述は二択誘導を避け、『どのような／なぜ／何／具体例』等の表現を用いる」旨を明記。
- fix(ui): 自由記述が表示されない問題を解消
  - `app/main.py: _looks_like_question` を拡張し、「自由記述」を含む行も質問として認識。
  - pending 抽出後は `(text, type)` で yes/no と open を出し分け（radio/text_area）。
- chore(fallback): フォールバック質問も 8+2 へ整備
  - `app/llm.py` と `app/main.py` の定型文を「何ですか？」「どのような〜ですか？」型へ調整。
- chore(genai): `google-genai` が未インストールでも動作するように try-import + 警告ログ（LLM なし時はフォールバック動作）。

### 確認方法
1. アプリ起動: `uv run streamlit run app/main.py`
2. 新規アイデア作成 → 初回の「未回答の質問」が 10 件で表示され、末尾 2 件がテキスト入力（「回答（任意）」）になっていることを確認。
3. 回答送信後に次の質問が再び 8+2 構成で表示されることを確認。
4. API キー未設定（または一時的エラー）でも 10 件（8+2）で表示されることを確認。
5. これまでの質疑応答履歴と重複表示がないこと（末尾の pending 質問は履歴から除外）を確認。

### 影響範囲
- `app/llm.py`, `app/main.py`（質問生成・UI 表示・フォールバック）
- 既存データ互換は維持（既存メッセージはそのまま、次ラウンド以降が 8+2 に揃う）

### リスク・互換性
- LLM 出力の表現ゆれにより、極稀に自由記述に「はい/いいえ」語が混入する可能性はあるが、正規化で括弧書きは除去。
- 質問数固定（10 件）によりトークン消費がやや増加。

### 関連・メモ
- PR: #18（質問拡張と自由記述対応）
- 同時に API キー未設定時の UX も改善（警告ログ + フォールバック）

### テスト結果（ローカル）
- `uv run ruff check app/`: OK
- `uv run pytest -q`: 145 passed
- 動作確認: 自由記述が UI の末尾 2 件としてテキスト入力表示されることを確認

### スクリーンショット
- 8 件（はい/いいえ）+ 2 件（自由記述）で表示されていることが分かる画面を添付予定
