### PR TITLE
feat(ui): in-app prompt editor (session-only) + import/export

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1277,13 +1277,11 @@ def prompt_editor_ui():
             key="inv_prompt_editor_text",
             height=360,
         )
-        btns2 = st.columns(3)
+        btns2 = st.columns(2)
         if btns2[0].button("セッションに反映", key="apply_inv"):
             state.custom_invention_prompt = inv_val
             st.success("セッションのカスタムプロンプトを更新しました。")
-        if btns2[1].button("MDをダウンロード", key="save_inv"):
-            pass
-        if btns2[2].button("初期化（リポジトリ版に戻す）", key="reset_inv"):
+        if btns2[1].button("初期化（リポジトリ版に戻す）", key="reset_inv"):
             # Defer setting widget state until next rerun
             st.session_state["inv_prompt_reset_to"] = default_inv_md
             state.custom_invention_prompt = ""
@@ -1300,102 +1298,19 @@ def prompt_editor_ui():
             key="spec_prompt_editor_text",
             height=360,
         )
-        btns = st.columns(3)
+        btns = st.columns(2)
         if btns[0].button("セッションに反映"):
             state.custom_spec_prompt = spec_val
             st.success("セッションのカスタムプロンプトを更新しました。")
-        # Cloud: no server-side persistence. Offer MD download instead.
-        if btns[1].button("MDをダウンロード"):
-            # no-op; use the download buttons below for actual export
-            pass
-        if btns[2].button("初期化（リポジトリ版に戻す）"):
+        if btns[1].button("初期化（リポジトリ版に戻す）"):
             st.session_state["spec_prompt_reset_to"] = default_spec_md
             state.custom_spec_prompt = ""
             st.rerun()
-
-        # Execute with selected idea
-        idea_id = state.selected_idea_id
-        st.markdown("---")
-        st.markdown("#### このプロンプトで実行")
-        disabled = not idea_id
-        col_x, col_y = st.columns(2)
-        if col_x.button("このプロンプトで発明説明書を再生成", disabled=disabled, type="primary"):
-            idea = get_idea(st.session_state.ideas, cast(str, idea_id)) if idea_id else None
-            if idea:
-                with st.status("再生成中…", expanded=False):
-                    try:
-                        attachment_dicts, gemini_files = _prepare_attachment_dicts(idea)
-                        new_text, err = generate_invention_description(
-                            inv_val,
-                            idea.title,
-                            idea.description,
-                            transcript=idea.messages,
-                            attachments=attachment_dicts,
-                            gemini_files=gemini_files,
-                        )
-                        if err:
-                            st.warning(f"⚠️ 再生成で問題が発生しました: {err}")
-                        idea.invention_description_markdown = new_text
-                        save_ideas(st.session_state.ideas)
-                        st.success("発明説明書を更新しました。")
-                    except Exception as e:
-                        st.error(f"エラー: {e}")
-        if col_y.button("戻る"):
-            state.show_prompt_editor = False
-            st.rerun()
-
-    # Import/Export controls (session-only)
-    import json
-
+    # 画面を閉じる
     st.markdown("---")
-    st.markdown("### インポート / エクスポート（セッション用）")
-    cexp1, cexp2, cexp3, cexp4 = st.columns(4)
-    # Combined JSON download of both prompts (current editor values)
-    combined = {
-        "spec_instruction_md": st.session_state.get(
-            "spec_prompt_editor_text", state.custom_spec_prompt
-        ),
-        "invention_instruction_md": st.session_state.get(
-            "inv_prompt_editor_text", state.custom_invention_prompt
-        ),
-    }
-    json_bytes = json.dumps(combined, ensure_ascii=False, indent=2).encode("utf-8")
-    cexp1.download_button(
-        label="JSONをダウンロード",
-        data=json_bytes,
-        file_name="prompt_overrides.json",
-        mime="application/json",
-        use_container_width=True,
-    )
-    # Per-tab MD quick downloads
-    cexp2.download_button(
-        label="Spec MDをDL",
-        data=(st.session_state.get("spec_prompt_editor_text") or "").encode("utf-8"),
-        file_name="spec_prompt.md",
-        mime="text/markdown",
-        use_container_width=True,
-    )
-    cexp3.download_button(
-        label="Invention MDをDL",
-        data=(st.session_state.get("inv_prompt_editor_text") or "").encode("utf-8"),
-        file_name="invention_prompt.md",
-        mime="text/markdown",
-        use_container_width=True,
-    )
-    uploaded = cexp4.file_uploader("JSONを読み込み", type=["json"], label_visibility="collapsed")
-    if uploaded is not None:
-        try:
-            data = json.loads(uploaded.read().decode("utf-8"))
-            spec_md = data.get("spec_instruction_md") or ""
-            inv_md = data.get("invention_instruction_md") or ""
-            # Defer widget content updates to next rerun
-            st.session_state["spec_prompt_reset_to"] = spec_md
-            st.session_state["inv_prompt_reset_to"] = inv_md
-            state.custom_spec_prompt = spec_md
-            state.custom_invention_prompt = inv_md
-            st.rerun()
-        except Exception as e:
-            st.error(f"JSON読み込みに失敗しました: {e}")
+    if st.button("戻る"):
+        state.show_prompt_editor = False
+        st.rerun()
 
 
 def main():

--- a/app/main.py
+++ b/app/main.py
@@ -1269,10 +1269,12 @@ def prompt_editor_ui():
     with tab_inv:
         default_inv_md = _load_invention_instruction_markdown()
         current_inv = state.custom_invention_prompt or default_inv_md
+        # Avoid setting both value= and session_state for the same key
+        if "inv_prompt_editor_text" not in st.session_state:
+            st.session_state["inv_prompt_editor_text"] = current_inv
         inv_val = st.text_area(
             "発明説明書用プロンプト (Markdown)",
             key="inv_prompt_editor_text",
-            value=current_inv,
             height=360,
         )
         btns2 = st.columns(3)
@@ -1291,10 +1293,11 @@ def prompt_editor_ui():
     with tab_spec:
         default_spec_md = _load_instruction_markdown()
         current_spec = state.custom_spec_prompt or default_spec_md
+        if "spec_prompt_editor_text" not in st.session_state:
+            st.session_state["spec_prompt_editor_text"] = current_spec
         spec_val = st.text_area(
             "明細書ドラフト用プロンプト (Markdown)",
             key="spec_prompt_editor_text",
-            value=current_spec,
             height=360,
         )
         btns = st.columns(3)

--- a/app/main.py
+++ b/app/main.py
@@ -1327,31 +1327,58 @@ def prompt_editor_ui():
             spec_text.strip() != (spec_applied or "").strip()
         )
 
-        st.markdown("---")
-        if has_unsaved:
-            st.warning("編集中のプロンプトがセッションに反映されていません。どのように進みますか？")
-            c1, c2, c3 = st.columns(3)
-            if c1.button("セッションに反映して新規作成へ"):
-                state.custom_invention_prompt = inv_text
-                state.custom_spec_prompt = spec_text
-                st.session_state.pop("pending_nav_to", None)
-                state.show_prompt_editor = False
-                state.show_new_idea_form = True
-                st.rerun()
-            if c2.button("破棄して新規作成へ"):
-                st.session_state.pop("pending_nav_to", None)
-                state.show_prompt_editor = False
-                state.show_new_idea_form = True
-                st.rerun()
-            if c3.button("キャンセル"):
-                st.session_state.pop("pending_nav_to", None)
-                st.rerun()
+        # Prefer native modal if available
+        if has_unsaved and hasattr(st, "dialog"):
+            with st.dialog("未反映のプロンプトがあります"):
+                st.write(
+                    "編集中のプロンプトがセッションに反映されていません。どのように進みますか？"
+                )
+                st.caption("選択肢: 反映して進む / 破棄して進む / キャンセル")
+                c1, c2, c3 = st.columns(3)
+                if c1.button("セッションに反映して新規作成へ", type="primary"):
+                    state.custom_invention_prompt = inv_text
+                    state.custom_spec_prompt = spec_text
+                    st.session_state.pop("pending_nav_to", None)
+                    state.show_prompt_editor = False
+                    state.show_new_idea_form = True
+                    st.rerun()
+                if c2.button("破棄して新規作成へ"):
+                    st.session_state.pop("pending_nav_to", None)
+                    state.show_prompt_editor = False
+                    state.show_new_idea_form = True
+                    st.rerun()
+                if c3.button("キャンセル"):
+                    st.session_state.pop("pending_nav_to", None)
+                    st.rerun()
         else:
-            # No unsaved edits; proceed directly
-            st.session_state.pop("pending_nav_to", None)
-            state.show_prompt_editor = False
-            state.show_new_idea_form = True
-            st.rerun()
+            # Fallback inline confirmation (非モーダル)
+            if has_unsaved:
+                st.markdown("---")
+                st.warning(
+                    "編集中のプロンプトがセッションに反映されていません。どのように進みますか？"
+                )
+                c1, c2, c3 = st.columns(3)
+                if c1.button("セッションに反映して新規作成へ", type="primary"):
+                    state.custom_invention_prompt = inv_text
+                    state.custom_spec_prompt = spec_text
+                    st.session_state.pop("pending_nav_to", None)
+                    state.show_prompt_editor = False
+                    state.show_new_idea_form = True
+                    st.rerun()
+                if c2.button("破棄して新規作成へ"):
+                    st.session_state.pop("pending_nav_to", None)
+                    state.show_prompt_editor = False
+                    state.show_new_idea_form = True
+                    st.rerun()
+                if c3.button("キャンセル"):
+                    st.session_state.pop("pending_nav_to", None)
+                    st.rerun()
+            else:
+                # No unsaved edits; proceed directly
+                st.session_state.pop("pending_nav_to", None)
+                state.show_prompt_editor = False
+                state.show_new_idea_form = True
+                st.rerun()
 
     # 画面を閉じる
     st.markdown("---")

--- a/app/main.py
+++ b/app/main.py
@@ -265,26 +265,6 @@ def new_idea_form():
         "アイデアの詳細説明", height=160, placeholder="アイデアの概要を記載…"
     )
 
-    # Show which prompts will be used for this creation
-    state: AppState = st.session_state.app_state
-    st.markdown("### 使用するプロンプト（この新規作成）")
-    spec_is_custom = (state.custom_spec_prompt or "").strip() != ""
-    inv_is_custom = (state.custom_invention_prompt or "").strip() != ""
-    spec_label = "セッションのカスタム" if spec_is_custom else "既定（リポジトリ）"
-    inv_label = "セッションのカスタム" if inv_is_custom else "既定（リポジトリ）"
-    st.caption(f"明細書ドラフト用プロンプト: {spec_label}")
-    st.caption(f"発明説明書用プロンプト: {inv_label}")
-    with st.expander("プロンプトの先頭プレビュー", expanded=False):
-        spec_preview = (_get_current_spec_instruction() or "").strip().splitlines()[:6]
-        inv_preview = (_get_current_invention_instruction() or "").strip().splitlines()[:6]
-        st.markdown("**発明説明書（使用予定）**")
-        st.code("\n".join(inv_preview) or "(空)", language="markdown")
-        st.markdown("**明細書ドラフト（使用予定）**")
-        st.code("\n".join(spec_preview) or "(空)", language="markdown")
-    if st.button("プロンプトを編集する"):
-        state.show_prompt_editor = True
-        st.rerun()
-
     # File upload section
     st.markdown("### 関連ファイルの添付（任意）")
     uploaded_files = st.file_uploader(
@@ -303,6 +283,26 @@ def new_idea_form():
                 key=f"comment_{uploaded_file.name}",
             )
             attachments_to_add.append((uploaded_file, comment))
+
+    # Show which prompts will be used (moved below attachments)
+    state: AppState = st.session_state.app_state
+    st.markdown("### 使用するプロンプト（この新規作成）")
+    spec_is_custom = (state.custom_spec_prompt or "").strip() != ""
+    inv_is_custom = (state.custom_invention_prompt or "").strip() != ""
+    spec_label = "セッションのカスタム" if spec_is_custom else "既定（リポジトリ）"
+    inv_label = "セッションのカスタム" if inv_is_custom else "既定（リポジトリ）"
+    st.caption(f"明細書ドラフト用プロンプト: {spec_label}")
+    st.caption(f"発明説明書用プロンプト: {inv_label}")
+    with st.expander("プロンプトの先頭プレビュー", expanded=False):
+        spec_preview = (_get_current_spec_instruction() or "").strip().splitlines()[:6]
+        inv_preview = (_get_current_invention_instruction() or "").strip().splitlines()[:6]
+        st.markdown("**発明説明書（使用予定）**")
+        st.code("\n".join(inv_preview) or "(空)", language="markdown")
+        st.markdown("**明細書ドラフト（使用予定）**")
+        st.code("\n".join(spec_preview) or "(空)", language="markdown")
+    if st.button("プロンプトを編集する"):
+        state.show_prompt_editor = True
+        st.rerun()
 
     cols = st.columns(2)
     if cols[0].button("保存", type="primary"):

--- a/app/main.py
+++ b/app/main.py
@@ -742,8 +742,10 @@ def _render_pending_questions(
                 append_user_answer(idea.messages, ans)
             with st.spinner("ドラフト更新中…"):
                 attachment_dicts, gemini_files = _prepare_attachment_dicts(idea)
+                # Use the latest session-reflected prompts at submit time
+                current_spec_prompt = _get_current_spec_instruction()
                 spec_result, error_msg = regenerate_spec(
-                    manual_md,
+                    current_spec_prompt,
                     idea.description,
                     idea.messages,
                     attachments=attachment_dicts,
@@ -756,12 +758,16 @@ def _render_pending_questions(
                     idea.draft_spec_markdown = spec_result
                     idea.draft_version += 1
                     idea.spec_prompt_used = build_regenerate_spec_prompt_text(
-                        manual_md, idea.description, idea.messages, attachments=attachment_dicts
+                        current_spec_prompt,
+                        idea.description,
+                        idea.messages,
+                        attachments=attachment_dicts,
                     )
 
                 # Regenerate Invention Description in parallel
+                current_inv_prompt = _get_current_invention_instruction()
                 inv_text, inv_err = generate_invention_description(
-                    _load_invention_instruction_markdown(),
+                    current_inv_prompt,
                     idea.title,
                     idea.description,
                     transcript=idea.messages,
@@ -773,7 +779,7 @@ def _render_pending_questions(
                 else:
                     idea.invention_description_markdown = inv_text
                     idea.invention_prompt_used = build_invention_description_prompt_text(
-                        _load_invention_instruction_markdown(),
+                        current_inv_prompt,
                         idea.title,
                         idea.description,
                         transcript=idea.messages,

--- a/app/main.py
+++ b/app/main.py
@@ -224,13 +224,13 @@ def sidebar_ui():
         state.gemini_model = selected_model
         os.environ["GEMINI_MODEL"] = selected_model
 
-    # Move the idea list title below the model selector
-    st.sidebar.title("アイデア一覧")
-
-    # Prompt editor entry
+    # Prompt editor entry (show above idea list)
     if st.sidebar.button("📝 プロンプト編集", use_container_width=True):
         state.show_prompt_editor = True
         st.rerun()
+
+    # Move the idea list title below the prompt editor button
+    st.sidebar.title("アイデア一覧")
 
     # New idea button
     if st.sidebar.button("＋ 新規アイデアを作成", use_container_width=True):

--- a/app/state.py
+++ b/app/state.py
@@ -69,8 +69,16 @@ class AppState:
     selected_idea_id: Optional[str] = None
     # UI: new idea form visibility
     show_new_idea_form: bool = False
+    # UI: prompt editor visibility
+    show_prompt_editor: bool = False
     # Selected Gemini model (e.g., gemini-2.5-pro or gemini-2.5-flash)
     gemini_model: str = DEFAULT_MODEL_NAME
+
+    # Custom prompt overrides (session-level)
+    use_custom_spec_prompt: bool = False
+    custom_spec_prompt: str = ""
+    use_custom_invention_prompt: bool = False
+    custom_invention_prompt: str = ""
 
     def to_dict(self) -> Dict:
         return asdict(self)

--- a/app/state.py
+++ b/app/state.py
@@ -74,10 +74,8 @@ class AppState:
     # Selected Gemini model (e.g., gemini-2.5-pro or gemini-2.5-flash)
     gemini_model: str = DEFAULT_MODEL_NAME
 
-    # Custom prompt overrides (session-level)
-    use_custom_spec_prompt: bool = False
+    # Custom prompt overrides (session-level; present ⇒ always used)
     custom_spec_prompt: str = ""
-    use_custom_invention_prompt: bool = False
     custom_invention_prompt: str = ""
 
     def to_dict(self) -> Dict:

--- a/app/state.py
+++ b/app/state.py
@@ -49,6 +49,9 @@ class Idea:
     draft_spec_markdown: str = ""
     # Invention description (発明説明書 フルバージョン) Markdown
     invention_description_markdown: str = ""
+    # Prompts used for last generation (for confirmation display)
+    spec_prompt_used: str = ""
+    invention_prompt_used: str = ""
     # Draft version counter (1 = 初版)
     draft_version: int = 1
     # Whether this specification is finalized

--- a/app/storage.py
+++ b/app/storage.py
@@ -10,6 +10,7 @@ from .state import Idea, Revision
 
 DATA_DIR = Path(__file__).resolve().parent.parent / "data"
 IDEAS_PATH = DATA_DIR / "ideas.json"
+PROMPTS_PATH = DATA_DIR / "prompt_overrides.json"
 
 
 def ensure_data_dir() -> None:
@@ -17,6 +18,16 @@ def ensure_data_dir() -> None:
     if not IDEAS_PATH.exists():
         IDEAS_PATH.write_text(
             json.dumps({"ideas": []}, ensure_ascii=False, indent=2), encoding="utf-8"
+        )
+    # Create prompt overrides file if missing (empty defaults)
+    if not PROMPTS_PATH.exists():
+        PROMPTS_PATH.write_text(
+            json.dumps(
+                {"spec_instruction_md": "", "invention_instruction_md": ""},
+                ensure_ascii=False,
+                indent=2,
+            ),
+            encoding="utf-8",
         )
 
 
@@ -70,6 +81,32 @@ def save_ideas(ideas: List[Idea]) -> None:
     IDEAS_PATH.write_text(
         json.dumps(payload, ensure_ascii=False, indent=2, cls=DateTimeEncoder), encoding="utf-8"
     )
+
+
+def load_prompt_overrides() -> dict:
+    """Load prompt overrides persisted in the data directory.
+
+    Returns a dict with keys: spec_instruction_md, invention_instruction_md
+    (empty strings if not set)
+    """
+    ensure_data_dir()
+    try:
+        raw = json.loads(PROMPTS_PATH.read_text(encoding="utf-8"))
+        spec_md = raw.get("spec_instruction_md") or ""
+        inv_md = raw.get("invention_instruction_md") or ""
+        return {"spec_instruction_md": spec_md, "invention_instruction_md": inv_md}
+    except Exception:
+        return {"spec_instruction_md": "", "invention_instruction_md": ""}
+
+
+def save_prompt_overrides(spec_instruction_md: str, invention_instruction_md: str) -> None:
+    """Persist prompt overrides to the data directory."""
+    ensure_data_dir()
+    payload = {
+        "spec_instruction_md": spec_instruction_md or "",
+        "invention_instruction_md": invention_instruction_md or "",
+    }
+    PROMPTS_PATH.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
 
 
 def get_idea(ideas: List[Idea], idea_id: str) -> Optional[Idea]:


### PR DESCRIPTION
### 概要
「明細書ドラフト」「発明説明書」を作成するための指示プロンプトを、アプリ上で編集・実行できる機能を追加しました。クラウド前提（永続化なし）に合わせ、セッション内のみで保持し、JSON/Markdownのインポート／エクスポートを提供します。

### 背景
- 利用者がプロンプトを試行錯誤し、どの変更が出力品質に効くかを確認したいという要望に対応。
- クラウド上のStreamlit環境ではサーバー側永続化が難しいため、セッション内完結＋手動インポート/エクスポートで運用できる設計にしました。

### 変更点
- feat(ui): プロンプト編集・実行パネルを追加（サイドバー「📝 プロンプト編集」）
  - `app/main.py`
    - 新関数 `_get_current_spec_instruction()`／`_get_current_invention_instruction()` で、カスタムプロンプト（セッション）> 既定ファイルの優先順位に統一
    - `prompt_editor_ui()` を新設
      - タブ: 「明細書ドラフトの指示」「発明説明書の指示」
      - 「セッションに反映」トグルで以降の生成に適用
      - MD/JSON ダウンロード、JSONアップロード（両プロンプトまとめて）
      - 選択中アイデアに対して、その場でプロンプトを使って再生成（明細書`regenerate_spec()`／発明説明書`generate_invention_description()`）
    - 新規作成・初期生成・再生成の各フローで、カスタムが有効ならそれを使用
  - `app/state.py`
    - `AppState` にプロンプト管理用のフィールドを追加（セッション内のみ）
  - `app/storage.py`
    - 以前追加した永続化ヘルパは現状未使用（オンプレ等での将来拡張用）

### 確認方法
1. `uv run streamlit run app/main.py` で起動
2. サイドバー「📝 プロンプト編集」をクリック
3. 各タブでプロンプトを編集 → 「セッションに反映」をON
4. 画面下の「JSONをダウンロード」または「MDをDL」でエクスポート
   - 復元は「JSONを読み込み」から（セッションに即反映）
5. 「このプロンプトで◯◯を再生成」ボタンで、選択中アイデアの出力を更新

### 影響範囲
- 既存のヒアリング/生成フローは維持しつつ、プロンプト選択の経路が追加されました。
- セッションのみで完結（サーバー側への保存は行わない）
- 既存のテスト/仕様には非破壊で、UI追加は限定的です。

### リスク・互換性
- セッション終了でカスタム内容は失われます（設計どおり）。必要に応じてJSON/MDを手元保存してください。
- JSONインポート時のエラーはUIで通知し、適用は行いません。

### テスト結果（ローカル）
- `uv run ruff check app/ --fix`: OK
- `uv run ruff format app/`: OK
- `uv run pytest -q`: 147 passed

### スクリーンショット
- プロンプト編集タブ、インポート/エクスポート操作、実行ボタン（別途貼付）
