### PR TITLE
chore: .codex 削除と README 更新

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,3 +1,0 @@
-model = "gpt-5"
-model_reasoning_effort = "high"
-tools.web_search = true

--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ Icon?
 # Editors
 .vscode/
 .idea/
+
+# Local AI assistant config (not for commit)
+.codex/


### PR DESCRIPTION
### 概要
`.codex/` ディレクトリを削除し、`.gitignore` に追加して今後の混入を防止しました。併せて `README.md` を最新のリポジトリ運用ガイドライン（セットアップ/コマンド/テスト/PR運用等）に合わせて全面更新しました。

### 背景
- ローカル開発支援ツール用の `.codex/` は本番リポジトリに不要であり、誤ってコミットされやすいため除去・無視設定が必要でした。
- README が分散情報だったため、開発手順・品質ゲート・PR運用（PR_BODY.md のSSOT化）を明記してオンボーディング性を改善しました。

### 変更点
- chore: `.codex/` ディレクトリを削除
- chore: `.gitignore` に `.codex/` を追加
- docs(README): 以下を整理・追記
  - セットアップ/起動/開発コマンド（`uv sync`、`uv run streamlit run app/main.py`、ruff/pytest/pre-commit）
  - コーディング規約、テスト方針、コミット/PR運用（Conventional Commits、PR_BODY.md をSSOT）
  - セキュリティ/設定（`.env`、APIキー、フォールバック）

### 確認方法
1. `.codex/` が存在しないことを確認
2. `.gitignore` に `.codex/` が含まれていることを確認
3. `README.md` の更新内容（構成/コマンド/方針）が記載されていることを確認
4. 品質ゲートの実行
   - `uv run pytest -q`
   - `uv run pre-commit run --all-files`

### 影響範囲
- アプリ実行ロジックへの影響はありません（ドキュメント/構成のみ）。

### リスク・互換性
- 既存機能に非互換はありません。変更は削除/無視設定とドキュメントのみです。

### テスト結果（ローカル）
- `uv run pytest -q`: 147 passed
- `uv run pre-commit run --all-files`: 全フック Passed

### スクリーンショット
- なし（ドキュメント/構成変更のみ）
