### PR TITLE
fix(ui): サイドバーのアイデア選択が遷移しない不具合を修正

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -252,10 +252,14 @@ def sidebar_ui():
         if cols[0].button(f"{idea.title or '(無題)'}", key=f"sel-{idea.id}"):
             state.selected_idea_id = idea.id
             state.show_new_idea_form = False
+            # Ensure prompt editor does not keep overriding main area
+            state.show_prompt_editor = False
             st.rerun()
         if cols[1].button("編集", key=f"edit-{idea.id}"):
             state.selected_idea_id = idea.id
             state.show_new_idea_form = True
+            # Ensure prompt editor is closed when navigating to edit form
+            state.show_prompt_editor = False
             st.rerun()
         if cols[2].button("削除", key=f"del-{idea.id}"):
             st.session_state.ideas = delete_idea(ideas, idea.id)


### PR DESCRIPTION
### 概要
サイドバーのアイデア一覧からのクリック時に、プロンプト編集画面が優先表示されて遷移しない不具合を修正しました。

### 背景
- 事象: プロンプト編集画面を開いた状態で、左サイドバーのアイデア名（または編集）を押しても画面が切り替わらない。
- 原因: `state.show_prompt_editor` が True のまま維持され、メイン領域の分岐（`app/main.py:1481` 付近）で常に編集UIが描画されるため。サイドバー側でこのフラグを落としていなかった。

### 変更点
- `app/main.py`
  - サイドバーの「アイデア選択」クリック時に `state.show_prompt_editor = False` を明示的に設定。
  - サイドバーの「編集」クリック時にも `state.show_prompt_editor = False` を明示的に設定。
- これにより、プロンプト編集画面を開いていても、サイドバー操作で確実に目的の画面（閲覧/編集）へ遷移します。

### 確認方法
1) 品質ゲート
- `uv run pytest -q`（150 passed を確認）
- `uv run pre-commit run --all-files`（全て Passed を確認）

2) アプリでの手動動作確認
- 起動: `uv run streamlit run app/main.py`
- プロンプト編集を開く → サイドバーで任意のアイデア名をクリック → アイデア詳細に遷移すること。
- サイドバーの「編集」をクリック → アイデア編集フォームへ遷移すること。
- 「🏠 トップへ戻る」でトップに戻れること（既存動作の維持）。

### 影響範囲
- UIの状態遷移（サイドバー→メイン領域）に限定。LLM/ストレージ/エクスポート処理には非干渉。

### リスク・互換性
- プロンプト編集画面から離脱時、未反映のプロンプト内容がそのまま閉じられるケースがあります（ただしエディタ内容は `st.session_state` に保持され、再度開けば残っています）。
- 未反映の確認ダイアログ（強化UX）は別PRで検討可能です。

### 関連
- 該当Issue/PRがあれば追記してください。

### テスト結果/スクショ
- `uv run pytest -q` → 150 passed
- `uv run pre-commit run --all-files` → Passed
- スクリーンショットは必要に応じて追記します。
