### PR TITLE
fix(export): balance inline emphasis in PDF

### DIFF
--- a/app/export.py
+++ b/app/export.py
@@ -82,6 +82,42 @@ def parse_markdown(markdown_text: str) -> List[MarkdownElement]:
     return elements
 
 
+def _escape_html(text: str) -> str:
+    return text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
+
+def _format_emphasis(segment: str) -> str:
+    # Handle bold+italic before other emphasis to keep tag nesting balanced.
+    segment = re.sub(r"\*\*\*(.+?)\*\*\*", r"<b><i>\1</i></b>", segment)
+    segment = re.sub(r"\*\*(.+?)\*\*", r"<b>\1</b>", segment)
+    segment = re.sub(r"(?<!\*)\*(?!\*)(.+?)(?<!\*)\*(?!\*)", r"<i>\1</i>", segment)
+    return segment
+
+
+def md_inline_to_xhtml(text: str) -> str:
+    """Convert inline Markdown markers to simple XHTML understood by ReportLab."""
+
+    parts: list[str] = []
+    i = 0
+    while i < len(text):
+        if text[i] == "`":
+            j = text.find("`", i + 1)
+            if j != -1:
+                code = text[i + 1 : j]
+                parts.append(f"<font face='Courier'>{_escape_html(code)}</font>")
+                i = j + 1
+                continue
+        j = text.find("`", i)
+        segment = text[i : (j if j != -1 else len(text))]
+        if segment:
+            escaped = _escape_html(segment)
+            parts.append(_format_emphasis(escaped))
+        if j == -1:
+            break
+        i = j
+    return "".join(parts)
+
+
 def _add_md_inline_runs(paragraph, text: str) -> None:
     """Add runs to a python-docx paragraph by parsing simple inline Markdown.
 
@@ -244,33 +280,6 @@ def export_pdf(title: str, markdown_text: str) -> Tuple[str, bytes]:
     story: List[object] = []
     story.append(Paragraph(title or "特許明細書草案", style_title))
 
-    # Inline Markdown -> simple XHTML for Paragraph
-    def _md_inline_to_xhtml(text: str) -> str:
-        # Split by backticks to protect code spans
-        parts: list[str] = []
-        i = 0
-        while i < len(text):
-            if text[i] == "`":
-                j = text.find("`", i + 1)
-                if j != -1:
-                    code = text[i + 1 : j]
-                    esc = code.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
-                    parts.append(f"<font face='Courier'>{esc}</font>")
-                    i = j + 1
-                    continue
-            # Non-code chunk
-            j = text.find("`", i)
-            segment = text[i : (j if j != -1 else len(text))]
-            esc = segment.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
-            # Bold then italic (simple, non-nested)
-            esc = re.sub(r"\*\*(.+?)\*\*", r"<b>\1</b>", esc)
-            esc = re.sub(r"(?<!\*)\*(?!\*)(.+?)(?<!\*)\*(?!\*)", r"<i>\1</i>", esc)
-            parts.append(esc)
-            if j == -1:
-                break
-            i = j
-        return "".join(parts)
-
     # Helper to flush a pending list buffer to story
     def flush_list(buffer: list[MarkdownElement]) -> None:
         if not buffer:
@@ -280,7 +289,7 @@ def export_pdf(title: str, markdown_text: str) -> Tuple[str, bytes]:
         items: list[ListItem] = []
         if first.kind == "bullet":
             for el in buffer:
-                items.append(ListItem(Paragraph(_md_inline_to_xhtml(el.text), base)))
+                items.append(ListItem(Paragraph(md_inline_to_xhtml(el.text), base)))
             story.append(
                 ListFlowable(
                     items,
@@ -293,7 +302,7 @@ def export_pdf(title: str, markdown_text: str) -> Tuple[str, bytes]:
         elif first.kind == "number":
             start_num = first.number or 1
             for el in buffer:
-                items.append(ListItem(Paragraph(_md_inline_to_xhtml(el.text), base)))
+                items.append(ListItem(Paragraph(md_inline_to_xhtml(el.text), base)))
             story.append(
                 ListFlowable(
                     items,
@@ -334,17 +343,17 @@ def export_pdf(title: str, markdown_text: str) -> Tuple[str, bytes]:
             continue
 
         if element.kind == "quote":
-            story.append(Paragraph(_md_inline_to_xhtml(element.text), style_quote))
+            story.append(Paragraph(md_inline_to_xhtml(element.text), style_quote))
             continue
 
         if element.kind == "codeblock":
             # Use a Paragraph per line to keep CJK font while showing a code-like block
             for ln in (element.text or "").splitlines() or [""]:
-                story.append(Paragraph(_md_inline_to_xhtml(ln), style_code))
+                story.append(Paragraph(md_inline_to_xhtml(ln), style_code))
             continue
 
         # paragraph with inline styles
-        story.append(Paragraph(_md_inline_to_xhtml(element.text), base))
+        story.append(Paragraph(md_inline_to_xhtml(element.text), base))
 
     # Flush any trailing list
     flush_list(list_buffer)

--- a/app/export.py
+++ b/app/export.py
@@ -14,7 +14,7 @@ from reportlab.pdfbase import pdfmetrics
 from reportlab.pdfbase.cidfonts import UnicodeCIDFont
 from reportlab.platypus import ListFlowable, ListItem, Paragraph, SimpleDocTemplate, Spacer
 
-PDF_BASE_FONT = "STSong-Light"
+PDF_BASE_FONT = "HeiseiMin-W3"
 PDF_BOLD_FONT = "HeiseiKakuGo-W5"
 
 

--- a/app/export.py
+++ b/app/export.py
@@ -14,6 +14,9 @@ from reportlab.pdfbase import pdfmetrics
 from reportlab.pdfbase.cidfonts import UnicodeCIDFont
 from reportlab.platypus import ListFlowable, ListItem, Paragraph, SimpleDocTemplate, Spacer
 
+PDF_BASE_FONT = "STSong-Light"
+PDF_BOLD_FONT = "HeiseiKakuGo-W5"
+
 
 @dataclass
 class MarkdownElement:
@@ -86,10 +89,18 @@ def _escape_html(text: str) -> str:
     return text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
 
 
+def _wrap_bold(content: str) -> str:
+    return f"<font face='{PDF_BOLD_FONT}'><b>{content}</b></font>"
+
+
 def _format_emphasis(segment: str) -> str:
     # Handle bold+italic before other emphasis to keep tag nesting balanced.
-    segment = re.sub(r"\*\*\*(.+?)\*\*\*", r"<b><i>\1</i></b>", segment)
-    segment = re.sub(r"\*\*(.+?)\*\*", r"<b>\1</b>", segment)
+    segment = re.sub(
+        r"\*\*\*(.+?)\*\*\*",
+        lambda m: _wrap_bold(f"<i>{m.group(1)}</i>"),
+        segment,
+    )
+    segment = re.sub(r"\*\*(.+?)\*\*", lambda m: _wrap_bold(m.group(1)), segment)
     segment = re.sub(r"(?<!\*)\*(?!\*)(.+?)(?<!\*)\*(?!\*)", r"<i>\1</i>", segment)
     return segment
 
@@ -225,11 +236,12 @@ def export_pdf(title: str, markdown_text: str) -> Tuple[str, bytes]:
     buffer = BytesIO()
 
     # Register Japanese-capable CID font (built-in CJK font mapping)
-    try:
-        pdfmetrics.registerFont(UnicodeCIDFont("HeiseiKakuGo-W5"))
-    except Exception:
-        # Registration is idempotent; ignore if already registered or unavailable
-        pass
+    for font in (PDF_BASE_FONT, PDF_BOLD_FONT):
+        try:
+            pdfmetrics.registerFont(UnicodeCIDFont(font))
+        except Exception:
+            # Registration is idempotent; ignore if already registered or unavailable
+            pass
 
     # Document setup
     doc = SimpleDocTemplate(
@@ -244,7 +256,7 @@ def export_pdf(title: str, markdown_text: str) -> Tuple[str, bytes]:
     # Base styles with CJK wrapping
     base = ParagraphStyle(
         name="Base",
-        fontName="HeiseiKakuGo-W5",
+        fontName=PDF_BASE_FONT,
         fontSize=10,
         leading=14,
         spaceAfter=6,

--- a/tests/test_markdown_export_formatting.py
+++ b/tests/test_markdown_export_formatting.py
@@ -31,6 +31,6 @@ def test_markdown_rendered_in_docx_and_pdf():
 
 def test_md_inline_to_xhtml_balances_nested_emphasis():
     result = md_inline_to_xhtml("***強調*** 通常の文章")
-    assert "<b><i>強調</i></b>" in result
+    assert "<font face='HeiseiKakuGo-W5'><b><i>強調</i></b></font>" in result
     assert result.endswith(" 通常の文章")
     assert result.count("<b>") == result.count("</b>")

--- a/tests/test_markdown_export_formatting.py
+++ b/tests/test_markdown_export_formatting.py
@@ -5,7 +5,7 @@ from io import BytesIO
 from docx import Document
 from pypdf import PdfReader
 
-from app.export import export_docx, export_pdf
+from app.export import export_docx, export_pdf, md_inline_to_xhtml
 
 
 def test_markdown_rendered_in_docx_and_pdf():
@@ -27,3 +27,10 @@ def test_markdown_rendered_in_docx_and_pdf():
     assert "- 箇条書き" not in full_text
     assert "見出し" in full_text
     assert "箇条書き" in full_text
+
+
+def test_md_inline_to_xhtml_balances_nested_emphasis():
+    result = md_inline_to_xhtml("***強調*** 通常の文章")
+    assert "<b><i>強調</i></b>" in result
+    assert result.endswith(" 通常の文章")
+    assert result.count("<b>") == result.count("</b>")


### PR DESCRIPTION
### 概要
PDFエクスポートで通常文まで太字に見えてしまう問題を修正し、日本語CJKフォントを明示登録して文字化けを防ぎつつ強調表示を正しく切り替えるようにしました。

### 背景
- 現象: ReportLab側で `HeiseiKakuGo-W5` を常用していたため字面が太く、さらに `***強調***` の閉じタグが乱れて後続テキストまで太字化される。
- 目的: 日本語文書として自然に表示できる明朝体を基準に、Markdownで指定した箇所のみ太字（ゴシック体相当）に切り替えられるようにする。

### 変更点
- `app/export.py`
  - ベーススタイルを日本語対応の明朝フォント `HeiseiMin-W3` に変更し、強調時のみゴシック体 `HeiseiKakuGo-W5` を使用するようフォント登録処理を拡張。
  - Markdownインライン変換 `md_inline_to_xhtml` を更新し、`**...**` / `***...***` を太字フォントでラップしてタグバランスを保持。
- `tests/test_markdown_export_formatting.py`
  - 新しいフォントラップを想定したアサーションで変換結果を検証。

### 確認方法
1. `uv run pytest -q`
2. `uv run pre-commit run --all-files`
3. アプリからPDFエクスポートを実施し、平文が明朝体、強調がゴシック体で表示され文字化けが発生しないことを目視確認。

### 影響範囲
- PDFエクスポートのフォント設定およびインラインMarkdown変換のみ（DOCX等は非影響）。

### リスク・互換性
- 利用環境でCIDフォントが利用不可の場合は別フォントへのフォールバックが必要になる可能性あり（現状は例外を握り潰しつつ継続）。

### 関連
- なし

### テスト結果/スクショ
- `uv run pytest -q` → 151 passed
- `uv run pre-commit run --all-files` → Passed
